### PR TITLE
Make some small fixes to episode 3

### DIFF
--- a/episodes/03-muscle-connect.md
+++ b/episodes/03-muscle-connect.md
@@ -32,7 +32,11 @@ MUSCLE3 consist of three components:
 
 **ymmsl-python** is a Python library that contains class definitions to represent an MMSL model description. A yMMSL file serves as the interface between us (humans) and the muscle manager and is meant to describe the multiscale simulation and tell the muscle manager what to do.
 
-We continue with the reaction-diffusion model example that we used in the previous episode and in this episode we will connect an implementation of the reaction model to the MUSCLE3 library step by step.
+In this section, we will be working with a simple 1-dimensional reaction-diffusion model. This model models a 1-dimensional medium in which some chemical is constantly destroyed by a reaction, while it is also diffusing through the medium. A reaction submodel models simple exponential growth (or decline in this case, with a negative parameter) for each cell in the 1D grid.  A diffusion submodel models diffusion through the 1D grid.
+
+Reaction-diffusion models are a traditional example case for multiscale modelling because depending on the parameters used, they may be time-scale overlapping, adjacent or separated. In this example, we're going to configure the diffusion model to be much slower than the reaction model, resulting in temporal scale separation.
+
+Before we can create our coupled simulation however, we will need to connect each submodel to MUSCLE3. Here, we will connect the reaction submodel to the `libmuscle` library step by step.
 
 ## Dissect your model
 
@@ -66,13 +70,13 @@ The function starts with defining some parameters that are used for the calculat
 Instead of using `.copy()`, we could also just assign `U` to equal the initial state (e.g. `U = initial_state`). For this particular example it would not matter since we do not use `initial_state` anymore. But if we did that, we would change the contents of `initial_state` every time we do an operation on `U`, because both variables would point to the same object. Since the variable is called `initial_state` it would be very confusing if it would change during the model execution. When you want to expand or change the model later on, it can be dangerous if variables do not behave as their name suggests.
 :::
 
-At every iteration of the loop, the state `U` is updated by adding a fraction of the old state, scaled by the parameter k and the size of a time step. Also the time counter `t_cur` is incremented with one time step. The `while` loop continues to run until `t_cur` has reached the value of the parameter `t_max`. Finally, when it exits the loop, the function returns the updated state `U`. 
+At every iteration of the loop, the state `U` is updated by adding a fraction of the old state, scaled by the parameter k and the size of a time step. Also the time counter `t_cur` is incremented with one time step. The `while` loop continues to run until `t_cur` has reached the value of the parameter `t_max`. Finally, when it exits the loop, the function returns the updated state `U`.
 
 ::: challenge
 
 ## Exercise 1: Can you recognize the Submodel Execution Loop?
 
- In the previous episode we have discussed the Submodel Execution Loop (SEL) and the various operators that are associated with it. In the code of the `reaction` function, can you recognize the beginning and end of the four operators ($F_{init}$, $O_I$, $S$ and $O_F$ ) plus the state update loop in this submodel? Mark these by placing the following 10 comments in the code:
+ In the previous episode we have discussed the Submodel Execution Loop (SEL) and the various operators that are associated with it. In the code of the `reaction` function, can you recognize the beginning and end of the four operators ($f_{init}$, $O_i$, $S$ and $O_f$ ) plus the state update loop in this submodel? Mark these by placing the following 10 comments in the code:
 
 - `# begin F_INIT`
 - `# end F_INIT`
@@ -120,14 +124,19 @@ def reaction(initial_state: np.array) -> np.array:
     # end O_F
 ```
 
-The Submodel Execution Loop specifies two operators within the state update loop. $O_I$ comes before $S$ and you can use it to send a message to the outside world with (part of) the current state. In this case, the $O_I$ operator is empty; we are not sending or storing any intermediate states. The original type annotations in the function definition serve the same purpose but we will be losing these once we are done connecting the model to MUSCLE.
+The Submodel Execution Loop specifies two operators within the state update
+loop. $O_i$ comes before $S$ and you can use it to send a message to the outside
+world with (part of) the current state. In this case, the $O_i$ operator is
+empty; we are not sending or storing any intermediate states. The original type
+annotations in the function definition serve the same purpose but we will be
+losing these once we are done connecting the model to MUSCLE.
 :::::
 
 :::
 
-## The constructor
+## Creating an Instance object
 
-To let a model communicate with the muscle manager, other submodels and the outside world, we need to create a `libmuscle.Instance` object:
+To let a model communicate with the muscle manager, other submodels and the outside world, we need to create a `libmuscle.Instance` object. An instance is a running submodel, and the Instance object represents this particular instance to MUSCLE3:
 
 ```python
 from libmuscle import Instance
@@ -141,7 +150,7 @@ def some_example_submodel():
             Operator.O_F: ['final_state_a', 'final_state_b']})
 ```
 
-The constructor takes a single argument, a dictionary that maps `ymmsl.Operator` objects to lists of ports. Ports are used by submodels to exchange messages with the outside world and eachother. These messages usually contain the state of the model, but they can also contain other information. Ports can be input ports or output ports, but not both at the same time, the operator that they are mapped to determines how the port is used. The names of the available operators correspond to their theoretical counterparts ($F_{init}$, $O_I$, $S$ and $O_F$ ).
+The constructor takes a single argument, a dictionary that maps `ymmsl.Operator` objects to lists of ports. Ports are used by submodels to exchange messages with the outside world and eachother. These messages usually contain (part of) the state of the model (including boundary conditions), but they can also contain other information. Ports can be input ports or output ports, but not both at the same time. The operator that they are mapped to determines how the port is used, as explained in the previous episode. The names of the available operators correspond to their theoretical counterparts ($f_{init}$, $O_i$, $S$ and $O_f$ ).
 
 ::: challenge
 
@@ -153,13 +162,15 @@ Question: In our example of the reaction submodel, what ports do we need to comm
 
 In this model, we need:
 
-- a single input port that will receive an initial state (e.g. named "initial_state") at the beginning of the model run and it should be mapped to the $F_{init}$ operator
-- a single output port that sends the final state (e.g. named "final_State") at the end of the reaction simulation to the rest of the simulation, it should be mapped to the $O_F$ operator
+- a single input port that will receive an initial state (e.g. named "initial_state") at the beginning of the model run and it should be mapped to the $f_{init}$ operator
+- a single output port that sends the final state (e.g. named "final_state") at the end of the reaction simulation to the rest of the simulation, it should be mapped to the $O_f$ operator
 ::::::
 
 :::
 
-In multiscale simulations, submodels often have to run multiple times, for instance because they are used as a micro model or because they are part of an ensemble that cannot be completely parallelised. In order to accomplish this, the entire submodel is wrapped into a loop. Exactly when this loop needs to end often depends on the behaviour of the whole model, and is not easy to determine beforehand, but fortunately MUSCLE will do that for us if we call the `libmuscle.Instance.reuse_instance()` method.
+## The reuse loop
+
+In multiscale coupled simulations, submodels often have to run multiple times, for instance because they are used as a micro model or because they are part of an ensemble that cannot be completely parallelised. To make this possible, we will wrap the entire submodel in a loop, the so-called reuse loop. Exactly when this loop needs to end often depends on the behaviour of the whole model, and is not easy to determine in advance, but fortunately MUSCLE will do that for us if we call the `libmuscle.Instance.reuse_instance()` method.
 
 ```python
     while instance.reuse_instance():
@@ -218,7 +229,7 @@ def reaction(initial_state: np.array) -> np.array:
         # end O_F
 ```
 
-Note that the type of data that is sent is documented in a comment. This is obviously not required, but it makes life a lot easier if someone else needs to use the code or you haven’t looked at it for a while, so it’s highly recommended.
+Note that the type of data that is sent is documented in a comment. This is obviously not required, but it makes life a lot easier if someone else needs to use the code or you haven’t looked at it for a while, so it’s highly recommended. MUSCLE3 does not require you to fix the type of the messages you're sending to a port in advance; in principle you could send a different type of message every time you send something. The latter is a bad idea, but the flexibility makes development much easier.
 
 ::::
 
@@ -226,7 +237,7 @@ Note that the type of data that is sent is documented in a comment. This is obvi
 
 ## Settings
 
-Next is the first part of the model, in which the model is initialised. Nearly every model needs some settings that define how it behaves (e.g. the size of a timestep or model specific parameters). We would like to control these settings centrally using the MUSCLE manager when starting up the coupled simulation so we don't have to change it in our model code every time if we want to try a range of values (for instance, to perform a sensitivity analysis). We can use the `libmuscle.Instance.get_setting` function instead to ask the MUSCLE manager for the values. The values, or ranges of values, should be recorded in the configuration file which we will cover in the next chapter.
+Next is the first part of the model, in which the model is initialised. Nearly every model needs some settings that define how it behaves (e.g. the size of a timestep or model specific parameters). With MUSCLE, we can specify settings for each submodel in a central configuration file, and get those settings from `libmuscle` in the model code. This way, we don't have to change our model code every time if we want to try a range of values (for instance, to perform a sensitivity analysis). We can use the `libmuscle.Instance.get_setting` function instead to ask the MUSCLE manager for the values. Putting the values in the configuration file will be covered in the next episode, here we'll look at how to get them from `libmuscle`.
 
 ```python
     some_variable = instance.get_setting('variable_name', 'variable_type')
@@ -241,11 +252,11 @@ The second argument, which specifies the expected type, is optional. If it is gi
 
 ::: challenge
 
-## Exercise 3: 
+## Exercise 3:
 
 In our example, several settings have been hard-coded into the model:
 
-- the total simulation time to run this sub-model, `tmax`
+- the total simulation time to run this sub-model, `t_max`
 - the time step to use, `dt`
 - and the model parameter, `k`
 
@@ -310,11 +321,11 @@ The `timestamp` attribute is a double precision float containing the number of s
 
 ## State update loop
 
-The actual state update happens in the operator $S$ in the Submodel Execution Loop and, in our example model, it is determined entirely by the current state. Since no information from outside is needed, we do not receive any messages, and in our `libmuscle.Instance` declaration above, we did not declare any ports associated with `Operator.S`. 
+The actual state update happens in the operator $S$ in the Submodel Execution Loop and, in our example model, it is determined entirely by the current state. Since no information from outside is needed, we do not receive any messages, and in our `libmuscle.Instance` declaration above, we did not declare any ports associated with `Operator.S`.
 
 The operator `O_I` provides for observations of intermediate states. In other words, here is where you can send a message to the outside world with (part of) the current state. In this case, the `O_I` operator is empty; we’re not sending anything.
 
-One thing we need to be aware of is time. Most models depend on time in some way and it is good to be aware of the various time frames. Libmuscles messages support passing on timestamps to be able to keep track of the global simulation time of the coupled model. It is easier to keep track of only one time frame and it is therefore good practice to add the timestamp that accompanied the initial state to the sub-model simulation time steps instead of starting at zero for every sub-model instance. 
+One thing we need to be aware of is time. Most models depend on time in some way and it is good to be aware of the various time frames. Libmuscles messages support passing on timestamps to be able to keep track of the global simulation time of the coupled model. It is easier to keep track of only one time frame and it is therefore good practice to add the timestamp that accompanied the initial state to the sub-model simulation time steps instead of starting at zero for every sub-model instance.
 
 :::challenge
 
@@ -360,7 +371,7 @@ def reaction() -> np.array:
 
 ## Time keeping
 
- Both `t_cur` and `t_max` used to be relative to the start of the submodel, but now represent absolute simulation time of the coupled system. The length of the while loop will not change, but in this way we would be able to send out the current global simulation time `t_cur` in the state update loop using the `I_O` operator. It is also possible to keep `t_cur` and `t_max` relative to the start of the submodel and only correct for the received global timestamp when you send out a message. It is often however preferable to keep track of only one single timeframe and make the corrections right at the receiving end. 
+ Both `t_cur` and `t_max` used to be relative to the start of the submodel, but now represent absolute simulation time of the coupled system. The length of the while loop will not change, but in this way we would be able to send out the current global simulation time `t_cur` in the state update loop using the `I_O` operator. It is also possible to keep `t_cur` and `t_max` relative to the start of the submodel and only correct for the received global timestamp when you send out a message. It is often however preferable to keep track of only one single timeframe and make the corrections right at the receiving end.
 :::::::::
 ::::::
 :::
@@ -384,7 +395,7 @@ from libmuscle import Grid, Message
 my_message = Message(my_timestamp, None, Grid(my_state, ['x']))
 ```
 
-To send the message we specify the port on which to send, which again needs to match the declaration.
+To send the message, we specify the port on which to send, which again needs to match the declaration.
 
 ```python
 libmuscle.Instance.send('final_state', final_message)
@@ -394,7 +405,7 @@ libmuscle.Instance.send('final_state', final_message)
 
 ## Exercise 5: Send back the result
 
-In the $O_F$ operator of your model construct a message and replace the return statement with a call to `libmuscle.Instance.send()` to send the final state to the outside world.
+In the $O_f$ operator of your model construct a message and replace the return statement with a call to `libmuscle.Instance.send()` to send the final state to the outside world.
 
 :::::: solution
 


### PR DESCRIPTION
Here are some small fixes to episode 3. The main thing is a small introduction of the reaction-diffusion model we'll use. I've also changed the heading for the section on the `Instance` object to explicitly mention that, because you do everything through the thing so I think it deserves to be a bit more center-stage. I've added a heading for the reuse loop for the same reason, that's a concept that keeps coming back too. The rest are formatting and typos.